### PR TITLE
Add Google Play Store Terraform provider configuration

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -144,3 +144,25 @@ provider "registry.terraform.io/hashicorp/time" {
     "zh:c239c619101a8c95e1f14061eb973c57a8d15fa0e68878ced5bbd76858ee5b79",
   ]
 }
+
+provider "registry.terraform.io/oliver-binns/googleplay" {
+  version     = "0.6.3"
+  constraints = "~> 0.6"
+  hashes = [
+    "h1:jwTBTt4Z//53nlV3lLw5tUimvKMekzmvcXGdMu/amBI=",
+    "zh:1761dc6c9db8b836194825909489646babd782bac0eda240093409444ebdfecd",
+    "zh:2478d235f52b45b41bc5e641eb0ef89a4bd212248fb41287877779f4d4d804cd",
+    "zh:2acee35baed1091f64d42295f5516a0bbeafc87f6c1575d151b0b73fa7dd7fa3",
+    "zh:353044e6392e124d79a9e16cd28b9a5e6ebce1febce7541417d07c254901e8b0",
+    "zh:3d203e4d9b568cbfcdfa84a3f98798360ade006b1225eb89d853a5c8c284b2a6",
+    "zh:4ec2178208001c29451d68e4a27060190ecbc0984f0d4789af21d026d24ec35f",
+    "zh:5643cb9a85463e0ad385a78db83e79b80a5c173544e759625286c4641dcbbcd7",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:89e98ecb07eb4b8edc3d3933768162085b19d0918a3800a6e2995c8203fa2c65",
+    "zh:8d685fcc8036c21702b30a0f8cfdf291419200b4477a23af6107bccdffb543b9",
+    "zh:99fbf4d2a7a91994eedc3ddb9df2103b5b576ab217556ccd885064c0a2c6456f",
+    "zh:a481b720e39b8c08a7fb0448aee770ced8f1040527bd1fa513989325be3e4456",
+    "zh:a9a2604a466d926c148e6f32d4c5e3f0f1530023248d86888f650e09ce82def0",
+    "zh:bdd771c30f491130dc1bebb58faeedb2dd1674004af0deb078f26dcdcac576c4",
+  ]
+}

--- a/androidapp.tf
+++ b/androidapp.tf
@@ -70,8 +70,12 @@ resource "google_service_account_iam_member" "github_actions_wif" {
   member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/attribute.google.subject/${each.value.subject}"
 }
 
-resource "googleplay_user" "github_actions" {
+resource "googleplay_app_iam" "github_actions" {
   for_each = var.android_apps
 
-  email = google_service_account.github_actions[each.key].email
+  user_id = google_service_account.github_actions[each.key].email
+  app_id  = each.value.app_id
+  permissions = [
+    "CAN_VIEW_NON_FINANCIAL_DATA"
+  ]
 }

--- a/androidapp.tf
+++ b/androidapp.tf
@@ -46,7 +46,7 @@ resource "google_iam_workload_identity_pool_provider" "github" {
 
   attribute_condition = length(var.android_apps) > 0 ? join(
     " || ",
-    tolist([for repo in values(var.android_apps) : "assertion.sub == '${repo.subject}'"])
+    tolist([for repo in values(var.android_apps) : "assertion.sub == '${repo.gh_oidc_subject}'"])
   ) : "assertion.sub != ''"
 }
 

--- a/androidapp.tf
+++ b/androidapp.tf
@@ -76,6 +76,6 @@ resource "googleplay_app_iam" "github_actions" {
   user_id = google_service_account.github_actions[each.key].email
   app_id  = each.value.android_app_id
   permissions = [
-    "CAN_VIEW_NON_FINANCIAL_DATA"
+    "CAN_VIEW_NON_FINANCIAL_DATA", "CAN_VIEW_APP_QUALITY"
   ]
 }

--- a/androidapp.tf
+++ b/androidapp.tf
@@ -69,3 +69,9 @@ resource "google_service_account_iam_member" "github_actions_wif" {
   role               = "roles/iam.workloadIdentityUser"
   member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/attribute.google.subject/${each.value.subject}"
 }
+
+resource "googleplay_user" "github_actions" {
+  for_each = var.android_apps
+
+  email = google_service_account.github_actions[each.key].email
+}

--- a/androidapp.tf
+++ b/androidapp.tf
@@ -67,14 +67,14 @@ resource "google_service_account_iam_member" "github_actions_wif" {
 
   service_account_id = google_service_account.github_actions[each.key].name
   role               = "roles/iam.workloadIdentityUser"
-  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/attribute.google.subject/${each.value.subject}"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/attribute.google.subject/${each.value.gh_oidc_subject}"
 }
 
 resource "googleplay_app_iam" "github_actions" {
   for_each = var.android_apps
 
   user_id = google_service_account.github_actions[each.key].email
-  app_id  = each.value.app_id
+  app_id  = each.value.android_app_id
   permissions = [
     "CAN_VIEW_NON_FINANCIAL_DATA"
   ]

--- a/production.tfvars
+++ b/production.tfvars
@@ -47,6 +47,8 @@ static_web_apps = {
   }
 }
 
+play_store_developer_id = "6400912963140305270"
+
 android_apps = {
   "game-gods-pet" = {
     subject = "repo:davidzenisu@32648667/game-gods-pet@1014907206"

--- a/production.tfvars
+++ b/production.tfvars
@@ -52,5 +52,6 @@ play_store_developer_id = "6400912963140305270"
 android_apps = {
   "game-gods-pet" = {
     subject = "repo:davidzenisu@32648667/game-gods-pet@1014907206"
+    app_id  = "com.zenisu.godspet"
   }
 }

--- a/production.tfvars
+++ b/production.tfvars
@@ -51,7 +51,7 @@ play_store_developer_id = "6400912963140305270"
 
 android_apps = {
   "game-gods-pet" = {
-    subject = "repo:davidzenisu@32648667/game-gods-pet@1014907206"
-    app_id  = "com.zenisu.godspet"
+    gh_oidc_subject = "repo:davidzenisu@32648667/game-gods-pet@1014907206"
+    android_app_id  = "com.zenisu.godspet"
   }
 }

--- a/providers.tf
+++ b/providers.tf
@@ -6,5 +6,5 @@ provider "cloudflare" {
 }
 
 provider "googleplay" {
-  developer_id                = var.play_store_developer_id
+  developer_id = var.play_store_developer_id
 }

--- a/providers.tf
+++ b/providers.tf
@@ -6,6 +6,5 @@ provider "cloudflare" {
 }
 
 provider "googleplay" {
-  service_account_json_base64 = filebase64(pathexpand("~/service-account.json"))
   developer_id                = var.play_store_developer_id
 }

--- a/providers.tf
+++ b/providers.tf
@@ -4,3 +4,8 @@ provider "azurerm" {
 
 provider "cloudflare" {
 }
+
+provider "googleplay" {
+  service_account_json_base64 = filebase64(pathexpand("~/service-account.json"))
+  developer_id                = var.play_store_developer_id
+}

--- a/terraform.tf
+++ b/terraform.tf
@@ -16,6 +16,10 @@ terraform {
       source  = "hashicorp/google"
       version = "~> 7.0"
     }
+    googleplay = {
+      source  = "Oliver-Binns/googleplay"
+      version = "~> 0.6"
+    }
   }
   backend "azurerm" {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -46,7 +46,8 @@ variable "play_store_developer_id" {
 variable "android_apps" {
   description = "A map of Android apps with the immutable GitHub OIDC subject token that may impersonate a dedicated service account."
   type = map(object({
-    subject = string
+    gh_oidc_subject = string
+    android_app_id  = string
   }))
   default = {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -37,6 +37,12 @@ variable "static_web_apps" {
   default = {}
 }
 
+variable "play_store_developer_id" {
+  description = "The Google Play Developer ID. Ideally passed as senstive environment variables (e.g. GitHub secret)."
+  type        = string
+  default     = null
+}
+
 variable "android_apps" {
   description = "A map of Android apps with the immutable GitHub OIDC subject token that may impersonate a dedicated service account."
   type = map(object({


### PR DESCRIPTION
Introduce the Google Play Store Terraform provider and configure it with necessary accounts. Remove redundant provider details to streamline the setup.